### PR TITLE
Add environment configurations and staging deployment docs

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,7 @@
+PORT=3000
+DATABASE_URL=postgresql://church_owner:password@localhost:5432/church?schema=public
+JWT_SECRET=dev-secret
+AWS_ACCESS_KEY_ID=dev-key
+AWS_SECRET_ACCESS_KEY=dev-secret
+AWS_REGION=us-east-1
+AWS_BUCKET_NAME=church-dev

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,7 @@
+PORT=3000
+DATABASE_URL=postgresql://church_owner:password@proddb:5432/church?schema=public
+JWT_SECRET=prod-secret
+AWS_ACCESS_KEY_ID=prod-key
+AWS_SECRET_ACCESS_KEY=prod-secret
+AWS_REGION=us-east-1
+AWS_BUCKET_NAME=church-prod

--- a/.env.stage
+++ b/.env.stage
@@ -1,0 +1,7 @@
+PORT=3000
+DATABASE_URL=postgresql://church_owner:password@stagedb:5432/church?schema=public
+JWT_SECRET=stage-secret
+AWS_ACCESS_KEY_ID=stage-key
+AWS_SECRET_ACCESS_KEY=stage-secret
+AWS_REGION=us-east-1
+AWS_BUCKET_NAME=church-stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,11 +39,15 @@ FROM node:22-alpine
 # Definir diretório de trabalho
 WORKDIR /app
 
+# Variável para escolher o arquivo de ambiente durante o build
+ARG ENV_FILE=.env.stage
+
 # Copiar apenas os arquivos necessários da etapa anterior
 COPY --from=build /app/prisma ./prisma
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-COPY .env.stage .env
+# Copiar o arquivo de variáveis de ambiente correspondente
+COPY ${ENV_FILE} .env
 
 # Expor porta
 EXPOSE 3000

--- a/README.md
+++ b/README.md
@@ -1,35 +1,68 @@
-Subindo imagem dockerfile no docker hub para x86_x64
+# Church Management API
 
-docker buildx build --platform linux/amd64,linux/arm64 -t dan1993/api-church:latest --push .
+Esta aplicação Node.js fornece a API do sistema de gestão de igrejas.
+Abaixo estão as instruções de uso nos ambientes **dev**, **stage** e **prod**.
 
----------------
+## Estrutura de ambientes
+- `.env.dev`   - variáveis de ambiente para desenvolvimento
+- `.env.stage` - variáveis de ambiente para staging
+- `.env.prod`  - variáveis de ambiente para produção
 
-Banco de Dados Prisma:
-
-DATABASE_URL="postgresql://usuario:senha@localhost:5432/db?schema=public"
-
------------------------
-
-
-# 📦 Helm Chart - Church API
-
-Este chart instala o backend da Church Management API em clusters Kubernetes com suporte a:
-
-- Deploy em multicloud (AKS, EKS, GKE)
-- Readiness & Liveness probes
-- Autoescalonamento com HPA
-- Ingress com TLS (Cert Manager)
-- Secrets gerenciados com ExternalSecrets
-- Monitoramento com Prometheus
+A imagem Docker permite escolher qual arquivo de ambiente será copiado através do argumento `ENV_FILE`.
 
 ---
 
-## 🛠️ Como usar
+## Desenvolvimento local
+1. Instale as dependências (`yarn install`).
+2. Copie as variáveis de ambiente:
+   ```bash
+   cp .env.dev .env
+   ```
+3. Suba a aplicação e o banco de dados com Docker Compose:
+   ```bash
+   docker-compose up --build
+   ```
+   ou rode diretamente com o Node:
+   ```bash
+   yarn dev
+   ```
 
-### 1. Instalar
+## Ambiente de staging
+1. Construa a imagem usando o arquivo de ambiente de stage:
+   ```bash
+   docker build --build-arg ENV_FILE=.env.stage -t church-api:stage .
+   ```
+2. Faça o push para o registro de imagens desejado.
+3. Implante no Kubernetes usando Helm:
+   ```bash
+   helm upgrade --install church-api-stage ./helm/church-api \
+     -n stage \
+     -f helm/church-api/values-stage.yaml
+   ```
+
+## Produção
+1. Gere a infraestrutura (AKS, EKS, etc.) com Terraform:
+   ```bash
+   cd infra
+   terraform init
+   terraform apply -var-file=terraform.tfvars
+   ```
+2. Construa e envie a imagem multi-arquitetura com o arquivo de produção:
+   ```bash
+   docker buildx build --platform linux/amd64,linux/arm64 \
+     --build-arg ENV_FILE=.env.prod \
+     -t dan1993/church-api:latest --push .
+   ```
+3. Faça o deploy com Helm:
+   ```bash
+   helm upgrade --install church-api ./helm/church-api \
+     -n production \
+     -f helm/church-api/values-prod.yaml
+   ```
+
+## Testes
+Para validar a compilação do código TypeScript execute:
 ```bash
-helm upgrade --install church-api ./helm/church-api \
-  -n production \
-  -f helm/church-api/values-prod.yaml
-
-
+yarn build
+```
+As dependências devem estar instaladas previamente (`yarn install`).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    environment:
-      - DATABASE_URL=postgresql://church_owner:8y0QkdXvajGY@ep-autumn-moon-a4qe2dmq.us-east-1.aws.neon.tech/church?sslmode=require
+      args:
+        ENV_FILE: .env.dev
+    env_file:
+      - .env.dev
     ports:
       - "3000:3000"
     depends_on:

--- a/helm/church-api/values-stage.yaml
+++ b/helm/church-api/values-stage.yaml
@@ -1,0 +1,44 @@
+replicaCount: 2
+
+image:
+  repository: dan1993/church-api
+  pullPolicy: IfNotPresent
+  tag: "stage"
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+  hosts:
+    - host: stage.api.igrejaviva.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - secretName: church-api-stage-tls
+      hosts:
+        - stage.api.igrejaviva.com
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+env:
+  - name: NODE_ENV
+    value: "staging"

--- a/infra/terraform.dev.tfvars
+++ b/infra/terraform.dev.tfvars
@@ -1,0 +1,6 @@
+location     = "eastus"
+environment  = "dev"
+cluster_name = "church-api-aks-dev"
+resource_group_name = "rg-church-api-dev"
+node_count   = 1
+node_size    = "Standard_B2s"

--- a/infra/terraform.stage.tfvars
+++ b/infra/terraform.stage.tfvars
@@ -1,0 +1,6 @@
+location     = "eastus"
+environment  = "staging"
+cluster_name = "church-api-aks-stage"
+resource_group_name = "rg-church-api-stage"
+node_count   = 2
+node_size    = "Standard_DS2_v3"


### PR DESCRIPTION
## Summary
- add sample environment files for dev/stage/prod
- update Dockerfile to allow ENV_FILE build argument
- configure docker-compose for development
- add Helm values for staging and Terraform tfvars for dev/stage
- rewrite README with instructions for running and deploying each environment

## Testing
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn install` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68898d28d304832898020823404bdb76