### PR TITLE
Improve AKS Terraform and CI/CD

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -5,10 +5,10 @@ on:
     branches: [ "main" ]
   workflow_dispatch:
     inputs:
-        environment:
-          description: "Ambiente (dev ou prod)"
-          required: true
-          default: "dev"
+      environment:
+        description: "Ambiente (dev, staging ou prod)"
+        required: true
+        default: "dev"
 
 env:
   TF_VAR_location: "eastus"
@@ -31,23 +31,39 @@ jobs:
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
+      - name: Select tfvars file
+        id: tfvars
+        run: |
+          case "${{ github.event.inputs.environment }}" in
+            dev) echo "file=terraform.dev.tfvars" >> "$GITHUB_OUTPUT" ;;
+            staging) echo "file=terraform.stage.tfvars" >> "$GITHUB_OUTPUT" ;;
+            *) echo "file=terraform.tfvars" >> "$GITHUB_OUTPUT" ;;
+          esac
+
       - name: Terraform Init
         working-directory: ./infra
         run: terraform init
 
       - name: Terraform Plan
         working-directory: ./infra
-        run: terraform plan -var-file=terraform.tfvars
+        run: terraform plan -var-file=${{ steps.tfvars.outputs.file }}
 
       - name: Terraform Apply
+        id: apply
         working-directory: ./infra
-        run: terraform apply -auto-approve -var-file=terraform.tfvars
+        run: terraform apply -auto-approve -var-file=${{ steps.tfvars.outputs.file }}
 
-      - name: Set Kubeconfig
+      - name: Get kubeconfig
+        id: kubeconf
         working-directory: ./infra
         run: |
-          echo "${{ steps.deploy.outputs.kube_config }}" > kubeconfig
-          export KUBECONFIG=$(pwd)/kubeconfig
+          terraform output -raw kube_config > kubeconfig
+          echo "kube_config=$(cat kubeconfig)" >> "$GITHUB_OUTPUT"
+
+      - name: Set Kubeconfig
+        run: |
+          echo "${{ steps.kubeconf.outputs.kube_config }}" > ${{ runner.temp }}/kubeconfig
+          echo "KUBECONFIG=${{ runner.temp }}/kubeconfig" >> $GITHUB_ENV
 
       - name: Install Helm
         uses: azure/setup-helm@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,9 +16,13 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
+          cache: 'yarn'
 
       - name: Install Dependencies
-        run: npm ci
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
 
       # - name: Lint
       #   run: npm run lint

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: npm ci
-      - name: Run npm audit
-        run: npm audit --audit-level=high
+        run: yarn install --frozen-lockfile
+      - name: Run audit
+        run: yarn audit --groups dependencies --level high
       - name: Docker Scan
         uses: aquasecurity/trivy-action@master
         with:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ A imagem Docker permite escolher qual arquivo de ambiente será copiado através
    ```bash
    yarn dev
    ```
+## Ambiente de desenvolvimento em AKS
+1. Construa a imagem de desenvolvimento:
+```bash
+docker build --build-arg ENV_FILE=.env.dev -t church-api:dev .
+```
+2. Implante com Helm:
+```bash
+helm upgrade --install church-api-dev ./helm/church-api 
+  -n dev 
+  -f helm/church-api/values-dev.yaml
+```
+
 
 ## Ambiente de staging
 1. Construa a imagem usando o arquivo de ambiente de stage:
@@ -47,6 +59,7 @@ A imagem Docker permite escolher qual arquivo de ambiente será copiado através
    terraform init
    terraform apply -var-file=terraform.tfvars
    ```
+   Os arquivos `terraform.*.tfvars` definem parâmetros como `dns_prefix` e os limites de autoscaling (`node_min_count` e `node_max_count`). Ajuste-os conforme a necessidade do seu ambiente.
 2. Construa e envie a imagem multi-arquitetura com o arquivo de produção:
    ```bash
    docker buildx build --platform linux/amd64,linux/arm64 \

--- a/helm/church-api/values-dev.yaml
+++ b/helm/church-api/values-dev.yaml
@@ -1,0 +1,39 @@
+replicaCount: 1
+
+image:
+  repository: dan1993/church-api
+  pullPolicy: IfNotPresent
+  tag: "dev"
+
+service:
+  type: ClusterIP
+  port: 3000
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: dev.church-api.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 256Mi
+  requests:
+    cpu: 200m
+    memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+
+env:
+  - name: NODE_ENV
+    value: "development"

--- a/infra/helm/helm_release.tf
+++ b/infra/helm/helm_release.tf
@@ -2,10 +2,10 @@ resource "helm_release" "church_api" {
   name       = "church-api"
   repository = "https://charts.example.com" # ou local ./charts
   chart      = "./../../helm/church-api"
-  namespace  = "production"
+  namespace        = var.environment
   create_namespace = true
 
   values = [
-    file("../../helm/church-api/values-prod.yaml")
+    file("../../helm/church-api/values-${var.environment}.yaml")
   ]
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -7,11 +7,15 @@ resource "azurerm_kubernetes_cluster" "aks" {
   name                = var.cluster_name
   location            = var.location
   resource_group_name = var.resource_group_name
+  dns_prefix          = var.dns_prefix
 
   default_node_pool {
     name       = "default"
     node_count = var.node_count
     vm_size    = var.node_size
+    enable_auto_scaling = true
+    min_count           = var.node_min_count
+    max_count           = var.node_max_count
   }
 
   identity {

--- a/infra/terraform.dev.tfvars
+++ b/infra/terraform.dev.tfvars
@@ -4,3 +4,6 @@ cluster_name = "church-api-aks-dev"
 resource_group_name = "rg-church-api-dev"
 node_count   = 1
 node_size    = "Standard_B2s"
+dns_prefix   = "church-api-dev"
+node_min_count = 1
+node_max_count = 2

--- a/infra/terraform.stage.tfvars
+++ b/infra/terraform.stage.tfvars
@@ -4,3 +4,6 @@ cluster_name = "church-api-aks-stage"
 resource_group_name = "rg-church-api-stage"
 node_count   = 2
 node_size    = "Standard_DS2_v3"
+dns_prefix   = "church-api-stage"
+node_min_count = 2
+node_max_count = 3

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -4,3 +4,6 @@ cluster_name = "church-api-aks"
 resource_group_name = "rg-church-api"
 node_count   = 2
 node_size    = "Standard_DS2_v3"
+dns_prefix   = "church-api"
+node_min_count = 2
+node_max_count = 4

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -27,3 +27,18 @@ variable "node_size" {
   type        = string
   default     = "Standard_DS2_v2"
 }
+
+variable "dns_prefix" {
+  type        = string
+  description = "Prefixo DNS do AKS"
+}
+
+variable "node_min_count" {
+  type        = number
+  default     = 1
+}
+
+variable "node_max_count" {
+  type        = number
+  default     = 3
+}


### PR DESCRIPTION
## Summary
- improve Terraform for AKS autoscaling and dns
- configure Helm release by environment
- tweak CI to use yarn and build
- adjust security workflow
- fix CD workflow to correctly retrieve kubeconfig
- document new Terraform variables
- add dev helm values and choose tfvars per environment

## Testing
- `yarn install --frozen-lockfile` *(fails: RequestError due to no network)*
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68898ff5de4c8328bd14f240bc57e38c