### PR TITLE
Add basic multi-tenant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Abaixo estão as instruções de uso nos ambientes **dev**, **stage** e **prod**
 
 A imagem Docker permite escolher qual arquivo de ambiente será copiado através do argumento `ENV_FILE`.
 
+## Multi-tenancy
+Este projeto suporta multi-tenant usando subdomínios. Cada requisição deve conter o cabeçalho `x-tenant-subdomain` informando o subdomínio do tenant.
+
+O middleware resolve a conexão do banco de dados para o tenant e disponibiliza um cliente Prisma na propriedade `req.prisma`.
+
+Exemplo de chamada usando `curl`:
+
+```bash
+curl -H "x-tenant-subdomain: minhaigreja" \
+     -X POST http://localhost:3000/api/auth/login \
+     -d '{"email":"admin@igreja.com","password":"senha"}'
+```
+
+
 ---
 
 ## Desenvolvimento local

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -13,8 +13,11 @@ export const loginUser = async (req: Request, res: Response) => {
       });
     }
 
+    // Subdomínio do tenant vem do middleware
+    const tenant = req.tenantSubdomain as string;
+
     // Chama o serviço de login para o usuário
-    const result = await loginUserService(email, password);
+    const result = await loginUserService(req.prisma!, email, password, tenant);
 
     // Retorna o token JWT gerado
     return res.json({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,5 @@
 // src/index.ts
 
-import { PrismaClient } from '@prisma/client';
 import express from 'express';
 import userRoutes from './routes/userRoutes';
 import cellReportRoutes from './routes/cellReportRoutes';
@@ -10,14 +9,15 @@ import eventRoutes from './routes/eventRoutes';
 import memberRoutes from './routes/memberRoutes';
 import notificationRoutes from './routes/notificationRoutes';
 import registrationRoutes from './routes/registration.routes';
+import { tenantMiddleware } from './middleware/tenantMiddleware';
 
 
-const prisma = new PrismaClient();
 const app = express();
 
 // Use o CORS de forma global ou apenas nas rotas específicas
 app.use(cors()); // Aplica CORS globalmente
 app.use(express.json());
+app.use(tenantMiddleware);
 
 // Rotas de autenticação
 app.use('/api/auth', authRoutes);

--- a/src/middleware/tenantMiddleware.ts
+++ b/src/middleware/tenantMiddleware.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction } from 'express';
+import { getPrismaForTenant } from '../utils/prismaForTenant';
+
+export const tenantMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+) => {
+  const subdomainHeader = req.headers['x-tenant-subdomain'];
+  if (!subdomainHeader || typeof subdomainHeader !== 'string') {
+    return res.status(400).json({ error: 'Cabeçalho x-tenant-subdomain obrigatório' });
+  }
+  try {
+    req.prisma = await getPrismaForTenant(subdomainHeader);
+    req.tenantSubdomain = subdomainHeader;
+    next();
+  } catch (err) {
+    console.error('Erro ao resolver tenant', err);
+    return res.status(400).json({ error: 'Tenant inválido' });
+  }
+};

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -3,8 +3,6 @@ import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import axios from "axios";
 
-const prisma = new PrismaClient();
-
 // Configuração do JWT
 const JWT_SECRET = process.env.JWT_SECRET || "3f8dcb8b7bb7b9f8b5b4f95c6c7489e6b49d420315a469d9cf8c36fef8d1c743";
 
@@ -13,11 +11,19 @@ const validatePassword = async (inputPassword: string, storedPassword: string): 
   return bcrypt.compare(inputPassword, storedPassword); // Comparando as senhas hashadas
 };
 
-export const loginUserService = async (email: string, password: string) => {
+export const loginUserService = async (
+  prisma: PrismaClient,
+  email: string,
+  password: string,
+  tenantSubdomain: string
+) => {
   try {
-    // Verifica se o usuário existe no banco de dados do app
-    const user = await prisma.user.findUnique({
-      where: { email },
+    // Verifica se o usuário existe no banco de dados do tenant
+    const user = await prisma.user.findFirst({
+      where: {
+        email,
+        tenantSubdomain,
+      },
     });
 
     if (!user) {
@@ -26,11 +32,11 @@ export const loginUserService = async (email: string, password: string) => {
     }
 
     // Consultar o status do tenant no SaaS
-    const tenantSubdomain = user.tenantSubdomain; // Subdomínio do tenant
+    const userTenant = user.tenantSubdomain; // Subdomínio do tenant
 
     // Consultar o status do tenant via API do SaaS
     const { data: tenantStatus } = await axios.get(
-      `http://localhost:5000/api/tenants/status/${tenantSubdomain}`  // Altere o URL para o endpoint do SaaS
+      `http://localhost:5000/api/tenants/status/${userTenant}`  // Altere o URL para o endpoint do SaaS
     );
 
     // Verifica se o tenant está ativo
@@ -51,7 +57,7 @@ export const loginUserService = async (email: string, password: string) => {
     const token = jwt.sign(
       {
         userId: user.id,
-        tenantSubdomain: user.tenantSubdomain,  // Usando o tenantSubdomain em vez do tenantId
+        tenantSubdomain: userTenant,  // Usando o tenant do usuário
         email: user.email
       },
       JWT_SECRET,  // Sua chave secreta do JWT

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -5,7 +5,9 @@ declare global {
   namespace Express {
     interface Request {
       user?: IUser;
-      userId?: number; 
+      userId?: number;
+      tenantSubdomain?: string;
+      prisma?: import('@prisma/client').PrismaClient;
     }
   }
 }

--- a/src/utils/prismaForTenant.ts
+++ b/src/utils/prismaForTenant.ts
@@ -1,0 +1,12 @@
+import { PrismaClient } from '@prisma/client';
+import { getDatabaseUrlForTenant } from './getDatabaseUrlForTenant';
+
+const clients: Record<string, PrismaClient> = {};
+
+export const getPrismaForTenant = async (subdomain: string): Promise<PrismaClient> => {
+  if (!clients[subdomain]) {
+    const url = await getDatabaseUrlForTenant(subdomain);
+    clients[subdomain] = new PrismaClient({ datasources: { db: { url } } });
+  }
+  return clients[subdomain];
+};


### PR DESCRIPTION
## Summary
- set up middleware to resolve tenant subdomain and provide Prisma instance
- get Prisma clients per tenant
- adjust login service and controller to use tenant-aware Prisma
- document multi-tenant usage in README

## Testing
- `yarn build` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688ad0a7c004832894dda90e04ee7950